### PR TITLE
POSIX string replacement for secretNames

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ GitHub Action to fetch secrets from AWS Secrets Manager.
 ```yaml
 steps:
  - name: Read secrets from AWS Secrets Manager into environment variables
-   uses: action-factory/aws-secrets-manager-action@0.2.0
+   uses: action-factory/aws-secrets-manager-action@v0.2.0
    with:
     aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
     aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -42,7 +42,7 @@ steps:
         app1/dev/*
       ```
 - `parse_json`
-  - Secret values can be plan text strings or stringified JSON objects (valid or invalid!).
+  - Secret values can be plain text strings or stringified JSON objects (valid or invalid!).
   - If `parse_json: true` and secret value is a valid stringified JSON object, it will be parsed and flattened. Each of its key value pairs will become individual secrets.
   - Examples: 
 
@@ -55,6 +55,9 @@ steps:
 
 #### Note:
 - `${{ secrets.YOUR_SECRET_NAME }}` refers to [GitHub Secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets). Create the required secrets (e.g.: AWS credentials) in your GitHub repository before using this GitHub Action.
+- AWS credentials can be omitted if they are provided in the environment, per https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html
+- Secrets are added to the environment (env) using the same key as used in Secrets Manager, i.e. env.foo will refer to the secret with the name foo.
+- For secret names that are not POSIX compliant, a second environment variable will be set that is POSIX compliant, i.e. /foo/bar.value will be stored in the environment as /foo/bar.value and also as \_foo\_bar\_value
 
 ## Features
 - Can fetch secrets from AWS Secrets Manager and inject them into environment variables which can be used in subsequent steps in your workflow. 

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { isJSONObject, isJSONObjectString, flattenJSONObject, filterBy } from '../src/utils'
+import { isJSONObject, isJSONObjectString, flattenJSONObject, filterBy, getPOSIX } from '../src/utils'
 
 test('Invaid JSON object string test 1', () => {
     expect(isJSONObjectString('["abcd"]')).toBe(false)
@@ -33,4 +33,12 @@ test('FilterBy test', () => {
     expect(filterBy(items, '*ana')).toMatchObject(['Banana'])
     expect(filterBy(items, '*an')).toMatchObject([])
     expect(filterBy(items, '*an*')).toMatchObject(['Banana'])
+})
+
+test('getPOSIX tests', () => {
+    expect(getPOSIX("abcd")).toEqual("abcd")
+    expect(getPOSIX("100")).toEqual("_100")
+    expect(getPOSIX("my/test/3")).toEqual("my_test_3")
+    expect(getPOSIX("my/test/3.foo")).toEqual("my_test_3_foo")
+    expect(getPOSIX("/my_test/4")).toEqual("_my_test_4")
 })

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { isJSONObject, isJSONObjectString, flattenJSONObject, filterBy, getPOSIX } from '../src/utils'
+import { isJSONObject, isJSONObjectString, flattenJSONObject, filterBy, getPOSIXString } from '../src/utils'
 
 test('Invaid JSON object string test 1', () => {
     expect(isJSONObjectString('["abcd"]')).toBe(false)
@@ -35,10 +35,10 @@ test('FilterBy test', () => {
     expect(filterBy(items, '*an*')).toMatchObject(['Banana'])
 })
 
-test('getPOSIX tests', () => {
-    expect(getPOSIX("abcd")).toEqual("abcd")
-    expect(getPOSIX("100")).toEqual("_100")
-    expect(getPOSIX("my/test/3")).toEqual("my_test_3")
-    expect(getPOSIX("my/test/3.foo")).toEqual("my_test_3_foo")
-    expect(getPOSIX("/my_test/4")).toEqual("_my_test_4")
+test('getPOSIXString tests', () => {
+    expect(getPOSIXString("abcd")).toEqual("abcd")
+    expect(getPOSIXString("100")).toEqual("_100")
+    expect(getPOSIXString("my/test/3")).toEqual("my_test_3")
+    expect(getPOSIXString("my/test/3.foo")).toEqual("my_test_3_foo")
+    expect(getPOSIXString("/my_test/4")).toEqual("_my_test_4")
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import * as core from "@actions/core"
 import { SecretsManager } from 'aws-sdk'
 import { Inputs } from './constants'
-import { flattenJSONObject, isJSONObjectString, filterBy } from './utils'
+import { flattenJSONObject, isJSONObjectString, filterBy, getPOSIX } from './utils'
 
 // secretNames input string is a new line separated list of secret names. Take distinct secret names.
 const inputSecretNames: string[] = [...new Set(core.getInput(Inputs.SECRETS).split("\n").filter(x => x !== ""))]
@@ -131,7 +131,7 @@ const injectSecretValueMapToEnvironment = (secretValueMap: object, core): void =
     const secretValue = secretValueMap[secretName]
     core.setSecret(secretValue)
     // If secretName contains non-posix characters, it can't be read by the shell
-    var secretNamePOSIX = secretName.replace(/[^a-zA-Z0-9_]/g, "_")
+    const secretNamePOSIX = getPOSIX(secretName)
     core.debug(`Injecting secret: ${secretName} = ${secretValue}`)
     core.exportVariable(secretName, secretValue)
     core.debug(`Injecting secret: ${secretNamePOSIX} = ${secretValue}`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import * as core from "@actions/core"
 import { SecretsManager } from 'aws-sdk'
 import { Inputs } from './constants'
-import { flattenJSONObject, isJSONObjectString, filterBy, getPOSIX } from './utils'
+import { flattenJSONObject, isJSONObjectString, filterBy, getPOSIXString } from './utils'
 
 // secretNames input string is a new line separated list of secret names. Take distinct secret names.
 const inputSecretNames: string[] = [...new Set(core.getInput(Inputs.SECRETS).split("\n").filter(x => x !== ""))]
@@ -134,7 +134,7 @@ const injectSecretValueMapToEnvironment = (secretValueMap: object, core): void =
     core.exportVariable(secretName, secretValue)
     // If secretName contains non-posix characters, it can't be read by the shell
     // Get POSIX compliant name secondary env name that can be read by the shell
-    const secretNamePOSIX = getPOSIX(secretName)
+    const secretNamePOSIX = getPOSIXString(secretName)
     if (secretName !== secretNamePOSIX){
       core.debug(`Secret name '${secretName}' is not POSIX compliant.`)
       core.debug(`Injecting secondary secret: ${secretNamePOSIX} = ${secretValue}`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,8 +130,12 @@ const injectSecretValueMapToEnvironment = (secretValueMap: object, core): void =
   for (const secretName in secretValueMap) {
     const secretValue = secretValueMap[secretName]
     core.setSecret(secretValue)
+    // If secretName contains non-posix characters, it can't be read by the shell
+    var secretNamePOSIX = secretName.replace(/[^a-zA-Z0-9_]/g, "_")
     core.debug(`Injecting secret: ${secretName} = ${secretValue}`)
     core.exportVariable(secretName, secretValue)
+    core.debug(`Injecting secret: ${secretNamePOSIX} = ${secretValue}`)
+    core.exportVariable(secretNamePOSIX, secretValue)
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,12 +130,16 @@ const injectSecretValueMapToEnvironment = (secretValueMap: object, core): void =
   for (const secretName in secretValueMap) {
     const secretValue = secretValueMap[secretName]
     core.setSecret(secretValue)
-    // If secretName contains non-posix characters, it can't be read by the shell
-    const secretNamePOSIX = getPOSIX(secretName)
     core.debug(`Injecting secret: ${secretName} = ${secretValue}`)
     core.exportVariable(secretName, secretValue)
-    core.debug(`Injecting secret: ${secretNamePOSIX} = ${secretValue}`)
-    core.exportVariable(secretNamePOSIX, secretValue)
+    // If secretName contains non-posix characters, it can't be read by the shell
+    // Get POSIX compliant name secondary env name that can be read by the shell
+    const secretNamePOSIX = getPOSIX(secretName)
+    if (secretName !== secretNamePOSIX){
+      core.debug(`Secret name '${secretName}' is not POSIX compliant.`)
+      core.debug(`Injecting secondary secret: ${secretNamePOSIX} = ${secretValue}`)
+      core.exportVariable(secretNamePOSIX, secretValue)
+    }
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,7 +51,7 @@ export const filterBy = (items: Array<string>, filter: string): Array<string> =>
   return items.filter(item => new RegExp('^' + filter.replace(/\*/g, '.*') + '$').test(item))
 }
 
-export const getPOSIX = (data: string): string => {
+export const getPOSIXString = (data: string): string => {
   if (data.match(/^[0-9]/))
     data = "_".concat(data)
   return data.replace(/[^a-zA-Z0-9_]/g, "_")

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,3 +50,9 @@ export const flattenJSONObject = (data: object): object => {
 export const filterBy = (items: Array<string>, filter: string): Array<string> => {
   return items.filter(item => new RegExp('^' + filter.replace(/\*/g, '.*') + '$').test(item))
 }
+
+export const getPOSIX = (data: string): string => {
+  if (data.match(/^[0-9]/))
+    data = "_".concat(data)
+  return data.replace(/[^a-zA-Z0-9_]/g, "_")
+}


### PR DESCRIPTION
The workflow files and most shells do not support non-word characters for environment variable keys, so accessing those variables can prove difficult or impossible.
This change will cause a second variable to be set that is POSIX compliant

See also: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_235