### PR TITLE
fix(Issues8): align input options to match AWS

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,7 @@
 export enum Inputs {
-  AWS_ACCESS_KEY_ID = 'aws_access_key_id',
-  AWS_SECRET_ACCESS_KEY = 'aws_secret_access_key',
-  AWS_REGION = 'aws_region',
+  AWS_ACCESS_KEY_ID = 'aws-access-key-id',
+  AWS_SECRET_ACCESS_KEY = 'aws-secret-access-key',
+  AWS_REGION = 'aws-region',
   SECRETS = 'secrets',
-  PARSE_JSON = 'parse_json'
+  PARSE_JSON = 'parse-json'
 }


### PR DESCRIPTION
Match input options to the standard set by AWS Actions. Use dashes instead of underscores.