### PR TITLE
Add ability to use a session token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,5 @@ out
 
 # Editors
 .vscode
+*.iml
+.idea

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ steps:
   - Empty string can be used ONLY IF you are using a self-hosted GitHub Actions Runner on AWS EC2 instances with an IAM instance profile attached (should have the required [AWS Secrets Manager permissions](#iam-policy)).
 - `aws-secret-access-key`
   - Corresponding Secret Access Key of the IAM user.
-  - Empty string can be used ONLY IF you are using a self-hosted GitHub Actions Runner on AWS EC2 instances with an IAM instance profile attached (should have the required [AWS Secrets Manager permissions](#iam-policy))
+  - Empty string can be used ONLY IF you are using a self-hosted GitHub Actions Runner on AWS EC2 instances with an IAM instance profile attached (should have the required [AWS Secrets Manager permissions](#iam-policy)).
 - `aws-session-token`
-  - Corresponding Session Token for the IAM user's current session
-  - Optional
+  - Corresponding Session Token for the IAM user's current session.
+  - Optional (required ONLY IF you are using [AWS IAM temporary credentials](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html)).
 - `aws-region`
   - AWS region code which has your AWS Secrets Manager secrets.
   - Example: `us-east-1`.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,10 @@ steps:
   - Empty string can be used ONLY IF you are using a self-hosted GitHub Actions Runner on AWS EC2 instances with an IAM instance profile attached (should have the required [AWS Secrets Manager permissions](#iam-policy)).
 - `aws-secret-access-key`
   - Corresponding Secret Access Key of the IAM user.
-  - Empty string can be used ONLY IF you are using a self-hosted GitHub Actions Runner on AWS EC2 instances with an IAM instance profile attached (should have the required [AWS Secrets Manager permissions](#iam-policy)).
+  - Empty string can be used ONLY IF you are using a self-hosted GitHub Actions Runner on AWS EC2 instances with an IAM instance profile attached (should have the required [AWS Secrets Manager permissions](#iam-policy))
+- `aws-session-token`
+  - Corresponding Session Token for the IAM user's current session
+  - Optional
 - `aws-region`
   - AWS region code which has your AWS Secrets Manager secrets.
   - Example: `us-east-1`.

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   aws-secret-access-key:
     description: 'Corresponding Secret Access Key of the IAM user with the required AWS Secrets Manager permissions'
     required: true
+  aws-session-token:
+    description: 'Corresponding Session Token of the IAM user session with the required AWS Secrets Manager permissions'
+    required: false
   aws-region:
     description: 'The region of AWS Secrets Manager which contains your secrets (e.g.: us-east-1)'
     required: true

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: 'Corresponding Secret Access Key of the IAM user with the required AWS Secrets Manager permissions'
     required: true
   aws-session-token:
-    description: 'Corresponding Session Token of the IAM user session with the required AWS Secrets Manager permissions'
+    description: '(Optional) Corresponding Session Token of the IAM user session with the required AWS Secrets Manager permissions'
     required: false
   aws-region:
     description: 'The region of AWS Secrets Manager which contains your secrets (e.g.: us-east-1)'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,7 @@
 export enum Inputs {
   AWS_ACCESS_KEY_ID = 'aws-access-key-id',
   AWS_SECRET_ACCESS_KEY = 'aws-secret-access-key',
+  AWS_SESSION_TOKEN = 'aws-session-token',
   AWS_REGION = 'aws-region',
   SECRETS = 'secrets',
   PARSE_JSON = 'parse-json'

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,10 +8,15 @@ const inputSecretNames: string[] = [...new Set(core.getInput(Inputs.SECRETS).spl
 // Check if any secret name contains a wildcard '*'
 const hasWildcard: boolean = inputSecretNames.some(secretName => secretName.includes('*'))
 const shouldParseJSON = (core.getInput(Inputs.PARSE_JSON).trim().toLowerCase() === 'true')
-const AWSConfig = {
+let AWSConfig: any = {
   accessKeyId: core.getInput(Inputs.AWS_ACCESS_KEY_ID),
   secretAccessKey: core.getInput(Inputs.AWS_SECRET_ACCESS_KEY),
-  region: core.getInput(Inputs.AWS_REGION),
+  region: core.getInput(Inputs.AWS_REGION)
+}
+
+const awsSessionToken = core.getInput(Inputs.AWS_SESSION_TOKEN)
+if (awsSessionToken) {
+  AWSConfig.sessionToken = awsSessionToken
 }
 
 const getSecretsManagerClient = (config): SecretsManager => new SecretsManager(config)

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ const inputSecretNames: string[] = [...new Set(core.getInput(Inputs.SECRETS).spl
 // Check if any secret name contains a wildcard '*'
 const hasWildcard: boolean = inputSecretNames.some(secretName => secretName.includes('*'))
 const shouldParseJSON = (core.getInput(Inputs.PARSE_JSON).trim().toLowerCase() === 'true')
-let AWSConfig: any = {
+const AWSConfig: any = {
   accessKeyId: core.getInput(Inputs.AWS_ACCESS_KEY_ID),
   secretAccessKey: core.getInput(Inputs.AWS_SECRET_ACCESS_KEY),
   region: core.getInput(Inputs.AWS_REGION)


### PR DESCRIPTION
I must use AWS's SAML flow to get my authentication with AWS. This gives me the Access Key, Secret Access Key, and a Session Token, all three are required to be passed when using this flow. Thus I need to add this as an option input